### PR TITLE
fix: Predictions page UI fixes

### DIFF
--- a/frontend/src/components/layout/MainLayout.js
+++ b/frontend/src/components/layout/MainLayout.js
@@ -6,9 +6,7 @@ import MobileHeader from '../mobile/MobileHeader';
 import BottomNav from '../mobile/BottomNav';
 import UnlockKeystoreModal from '../vault/UnlockKeystoreModal';
 import DeviceLinkModal from '../vault/DeviceLinkModal';
-// import PushPermissionBanner from '../common/PushPermissionBanner';
 import { isMobile } from '../../utils/deviceDetection';
-import { isLoggedInState } from '../../services/auth';
 
 /**
  * Main layout component that provides the application shell
@@ -29,11 +27,8 @@ export default function MainLayout({ children }) {
     // Mobile header (only on mobile)
     MobileHeader({ onMenuToggle: toggleSidebar }),
 
-    // Push notification permission banner (only when logged in)
-    // () => isLoggedInState.val ? PushPermissionBanner() : null,
-
     div({ class: () => `wrapper ${isMobile.val ? 'mobile' : ''}` }, [
-      // Header(), 
+      // Header(),
       div({ class: "content-container" }, [
         Sidebar({ isOpen: sidebarOpen }),
         div({ class: "main-content" }, children)

--- a/frontend/src/components/predictions/LeaderboardCard.js
+++ b/frontend/src/components/predictions/LeaderboardCard.js
@@ -196,7 +196,7 @@ export default function LeaderboardCard() {
             th({ class: 'rank-header' }, 'Rank'),
             th({ class: 'user-header' }, 'User'),
             th({ class: 'points-header' }, 'Rep Points'),
-            th({ class: 'predictions-header' }, 'Predictions'),
+            th({ class: 'predictions-col-header' }, 'Predictions'),
             th({ class: 'accuracy-header' }, 'Avg Log Loss')
           ])
         ]),

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2555,27 +2555,30 @@ body.dark-mode .trades-table th {
 
 .user-stats-horizontal {
   display: flex;
-  flex-direction: row; /* Ensure row direction */
-  width: 100%; /* Ensure full width */
-  box-sizing: border-box; /* Include padding in width */
-  gap: 2rem;
-  justify-content: space-around; /* Distribute items evenly */
-  align-items: center;
-  flex-wrap: wrap;
-  padding: 1.5rem 2rem;
-  background-color: var(--card-bg); /* Add background */
-  border-radius: var(--border-radius); /* Add border radius */
-  border: 1px solid var(--border-color); /* Add border */
+  flex-direction: row;
+  width: 100%;
+  box-sizing: border-box;
+  gap: 1rem;
+  justify-content: space-around;
+  align-items: stretch;
+  flex-wrap: nowrap;
+  padding: 1rem 1.5rem;
+  background-color: var(--card-bg);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-color);
   box-shadow: var(--box-shadow);
-  margin-bottom: 2rem; /* Add spacing below */
+  margin-bottom: 1.5rem;
 }
 
 .user-stats-horizontal .stat-item {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   text-align: center;
-  min-width: 120px;
+  flex: 1;
+  min-width: 0;
+  padding: 0.5rem;
 }
 
 .user-stats-horizontal .stat-main {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1680,7 +1680,7 @@ body.dark-mode .notification-settings {
   line-height: 1.2;
 }
 
-.predictions-header {
+.predictions-col-header {
   text-align: center;
   width: 90px;
   vertical-align: middle;


### PR DESCRIPTION
## Summary
- Fix CSS class collision that caused user stats to display vertically instead of horizontally
- Remove push notification banner from main layout (was rendering function as text)
- Adjust layout so all 5 stat boxes display on the same row

## Test plan
- [ ] Navigate to predictions page
- [ ] Verify all 5 stat boxes (Balance, Available, Reputation, Rank, Predictions) display horizontally on one row
- [ ] Verify no debug text appears on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)