### PR TITLE
fix: Resolve MLS WASM concurrency bug with sequential async flow

### DIFF
--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -71,15 +71,6 @@ export async function onLoginSuccess(password = null) {
           // Set up vault store with user ID
           vaultStore.setUserId(profile.id);
 
-          // Initialize authenticated socket connection
-          socketService.initializeSocket();
-
-          // Start MLS bootstrap early (in background) so it's ready when vault needs it
-          // The lock in ensureMlsBootstrap prevents race conditions if called again
-          coreCryptoClient.ensureMlsBootstrap(String(profile.id)).catch(e =>
-            console.warn('[MLS] Background bootstrap failed:', e.message || e)
-          );
-
         // Privacy-Preserving Auth Flow:
         // We cannot check if a vault exists without the password (to derive the key/hash).
         // Since we have verified the password via login, we try to unlock.
@@ -159,7 +150,9 @@ export async function onLoginSuccess(password = null) {
              console.log('Passkey login without vault unlock. Vault remains locked.');
         }
 
-        // MLS key packages are uploaded after keystore setup completes
+          // Initialize socket AFTER vault operations complete
+          // MLS is now ready to handle incoming messages
+          socketService.initializeSocket();
       }
     } catch (profileError) {
       console.warn('Error during post-login vault setup:', profileError);

--- a/frontend/src/services/mls/coreCryptoClient.js
+++ b/frontend/src/services/mls/coreCryptoClient.js
@@ -303,10 +303,9 @@ class CoreCryptoClient {
             this.client.create_identity(username);
             this.client.regenerate_key_package();
             await this.saveState();
-            try {
-                const vault = await this.getVaultService();
-                await vault.saveCurrentState();
-            } catch (e) {}
+            // Note: saveCurrentState() is NOT called here during initial bootstrap
+            // because the IndexedDB record doesn't exist yet. The caller
+            // (setupKeystoreWithPassword) saves state after creating the record.
             this.setupSocketListeners();
         } catch (error) {
             console.error('Error bootstrapping MLS client:', error);


### PR DESCRIPTION
## Summary

- Fixed WASM MLS client panicking with "recursive use of an object" and "RuntimeError: unreachable" errors
- Root cause: Multiple JavaScript async operations accessing WASM client concurrently, violating Rust's borrow rules
- Solution: Enforce strict sequential async flow for all MLS operations

## Changes

**auth.js:**
- Remove fire-and-forget `ensureMlsBootstrap()` that raced with vault setup
- Move `socketService.initializeSocket()` to after vault operations complete

**vaultService.js:**
- Move `setDeviceId()` and `api.devices.register()` before `ensureMlsBootstrap()`
- Await `ensureKeyPackagesFresh()` instead of fire-and-forget

**coreCryptoClient.js:**
- Remove redundant `saveCurrentState()` call during bootstrap

## New Sequential Flow

```
1. Derive compositeKey
2. setDeviceId (local)
3. api.devices.register (server)
4. ensureMlsBootstrap (WASM)
5. exportStateForVault (WASM)
6. Write to IndexedDB
7. ensureKeyPackagesFresh (WASM) - awaited
8. socketService.initializeSocket()
```

## Test plan

- [x] Reset test users with `./tests/e2e/reset-test-users.sh`
- [x] Login as user1@example.com - no WASM errors
- [x] Login as user2@example.com - no WASM errors
- [x] Verify E2E messaging works between users
- [x] Console shows clean sequential flow with no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)