### PR TITLE
fix: harden update transaction cleanup and persuasive-alpha test/dev-setup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Intellacc is a prediction-market social network that combines a social feed, LMS
 
 4. Open the app.
 
-   Frontend: http://localhost:5175  
-   Backend API: http://localhost:3005  
+   Frontend: http://localhost:5175
+   Backend API: http://localhost:3005
    Prediction engine: http://localhost:3006
 
 Production runs separately on ports 5173/3000/3001.

--- a/README.md
+++ b/README.md
@@ -43,19 +43,27 @@ Intellacc is a prediction-market social network that combines a social feed, LMS
    prediction-engine/.env
    ```
 
-3. Start the stack.
+3. Start your local development stack (safe, isolated from production containers).
 
    ```sh
-   docker compose up -d
+   ./scripts/dev-stack.sh up
    ```
 
 4. Open the app.
 
-   Frontend: http://localhost:5173  
-   Backend API: http://localhost:3000  
-   Prediction engine: http://localhost:3001
+   Frontend: http://localhost:5175  
+   Backend API: http://localhost:3005  
+   Prediction engine: http://localhost:3006
+
+Production runs separately on ports 5173/3000/3001.
 
 ## Useful Commands
+
+- Local stack up: `./scripts/dev-stack.sh up`
+- Local stack down: `./scripts/dev-stack.sh down`
+- Local stack logs: `./scripts/dev-stack.sh logs`
+- Local stack status: `./scripts/dev-stack.sh status`
+- Production stack (from this repo): `docker compose up -d` (only if that's intentionally desired)
 
 - Logs: `docker logs -f intellacc_backend`
 - Logs: `docker logs -f intellacc_frontend`

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       dockerfile: Dockerfile
     container_name: intellacc_backend
     environment:
+      INTELLACC_STACK: production
       NODE_ENV: ${NODE_ENV}
       PORT: ${NODE_PORT}
       DATABASE_URL: ${DATABASE_URL}

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['<rootDir>/test/jest.closeDbAfterEach.js'],
+};

--- a/backend/migrations/20260216_add_persuasive_alpha_attribution_schema.sql
+++ b/backend/migrations/20260216_add_persuasive_alpha_attribution_schema.sql
@@ -1,0 +1,48 @@
+-- 2026-02-16: Persuasive Alpha foundation schema
+-- Adds post->market attribution primitives and optional market update referral metadata.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS post_market_matches (
+    id SERIAL PRIMARY KEY,
+    post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    match_score DECIMAL(10, 6) NOT NULL DEFAULT 0.0,
+    match_method VARCHAR(20) NOT NULL DEFAULT 'fts_v1',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT unique_post_market_match UNIQUE (post_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_post_market_matches_post ON post_market_matches(post_id);
+CREATE INDEX IF NOT EXISTS idx_post_market_matches_event ON post_market_matches(event_id);
+
+CREATE TABLE IF NOT EXISTS post_market_clicks (
+    id SERIAL PRIMARY KEY,
+    post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    clicked_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    consumed_at TIMESTAMP WITH TIME ZONE,
+    consumed_by_market_update_id INTEGER,
+    CONSTRAINT post_market_clicks_post_event_user_unique_once_per_click_window
+      UNIQUE (post_id, event_id, user_id, clicked_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_post_market_clicks_user_event_clicked
+    ON post_market_clicks(user_id, event_id, clicked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_post_market_clicks_expires
+    ON post_market_clicks(expires_at);
+
+ALTER TABLE market_updates
+    ADD COLUMN IF NOT EXISTS referral_post_id INTEGER REFERENCES posts(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS referral_click_id INTEGER,
+    ADD COLUMN IF NOT EXISTS had_prior_position BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_market_updates_referral_post
+    ON market_updates(referral_post_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_market_updates_referral_click
+    ON market_updates(referral_click_id);
+
+COMMIT;

--- a/backend/migrations/20260218_fix_persuasive_alpha_click_dedupe.sql
+++ b/backend/migrations/20260218_fix_persuasive_alpha_click_dedupe.sql
@@ -1,0 +1,14 @@
+-- 2026-02-18: Fix persuasive attribution click deduplication
+-- The previous unique constraint included clicked_at, which did not block
+-- multiple active clicks for the same user/event/post.
+
+BEGIN;
+
+ALTER TABLE post_market_clicks
+    DROP CONSTRAINT IF EXISTS post_market_clicks_post_event_user_unique_once_per_click_window;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_post_market_clicks_active_user_post_event
+    ON post_market_clicks (post_id, event_id, user_id)
+    WHERE consumed_at IS NULL;
+
+COMMIT;

--- a/backend/scripts/docker-dev-entrypoint.sh
+++ b/backend/scripts/docker-dev-entrypoint.sh
@@ -1,6 +1,25 @@
 #!/bin/sh
 set -e
 
+intellacc_stack="${INTELLACC_STACK:-}"
+if [ "$intellacc_stack" != "production" ] && [ "$intellacc_stack" != "development" ]; then
+  echo "FATAL: INTELLACC_STACK must be one of: production | development"
+  echo "Refusing to start backend without explicit environment mode."
+  exit 1
+fi
+
+if [ "$intellacc_stack" = "development" ] && [ "$HOSTNAME" != "intellacc_backend_dev" ]; then
+  echo "FATAL: development stack must run as container intellacc_backend_dev."
+  echo "Current container: $HOSTNAME"
+  exit 1
+fi
+
+if [ "$intellacc_stack" = "production" ] && [ "$HOSTNAME" != "intellacc_backend" ]; then
+  echo "FATAL: production stack must run as container intellacc_backend."
+  echo "Current container: $HOSTNAME"
+  exit 1
+fi
+
 # Wait for Postgres to become available
 until pg_isready -h db -p 5432 >/dev/null 2>&1; do
   echo "Waiting for DB"

--- a/backend/scripts/docker-dev-entrypoint.sh
+++ b/backend/scripts/docker-dev-entrypoint.sh
@@ -14,8 +14,8 @@ if [ "$intellacc_stack" = "development" ] && [ "$HOSTNAME" != "intellacc_backend
   exit 1
 fi
 
-if [ "$intellacc_stack" = "production" ] && [ "$HOSTNAME" != "intellacc_backend" ]; then
-  echo "FATAL: production stack must run as container intellacc_backend."
+if [ "$intellacc_stack" = "production" ] && [ -n "${INTELLACC_BACKEND_HOSTNAME:-}" ] && [ "$HOSTNAME" != "$INTELLACC_BACKEND_HOSTNAME" ]; then
+  echo "FATAL: production stack must run as container ${INTELLACC_BACKEND_HOSTNAME}."
   echo "Current container: $HOSTNAME"
   exit 1
 fi

--- a/backend/src/controllers/persuasiveAlphaController.js
+++ b/backend/src/controllers/persuasiveAlphaController.js
@@ -1,0 +1,112 @@
+const db = require('../db');
+
+const DEFAULT_CLICK_TTL_MINUTES = 30;
+
+const parseIntParam = (value, label) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return parsed;
+};
+
+const parseClickWindowMinutes = () => {
+  const configured = Number(process.env.POST_MARKET_CLICK_TTL_MINUTES);
+  if (!Number.isFinite(configured) || configured <= 0) {
+    return DEFAULT_CLICK_TTL_MINUTES;
+  }
+  return configured;
+};
+
+exports.createPostMarketClick = async (req, res) => {
+  try {
+    const postId = parseIntParam(req.params.postId, 'postId');
+    const eventId = parseIntParam(req.body?.event_id, 'event_id');
+    const userId = req.user?.id || req.user?.userId;
+    if (!userId) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    const postResult = await db.query('SELECT id FROM posts WHERE id = $1', [postId]);
+    if (postResult.rows.length === 0) {
+      return res.status(404).json({ message: 'Post not found' });
+    }
+
+    const eventResult = await db.query('SELECT id FROM events WHERE id = $1', [eventId]);
+    if (eventResult.rows.length === 0) {
+      return res.status(400).json({ message: 'Invalid event_id' });
+    }
+
+    const matchResult = await db.query(
+      `SELECT 1
+       FROM post_market_matches
+       WHERE post_id = $1
+         AND event_id = $2
+       LIMIT 1`,
+      [postId, eventId]
+    );
+    if (matchResult.rows.length === 0) {
+      return res.status(400).json({ message: 'No active market match for this post' });
+    }
+
+    const now = Date.now();
+    const ttlMinutes = parseClickWindowMinutes();
+    const expiresAt = new Date(now + ttlMinutes * 60 * 1000);
+
+    const insertResult = await db.query(
+      `INSERT INTO post_market_clicks (
+         post_id,
+         event_id,
+         user_id,
+         clicked_at,
+         expires_at
+       ) VALUES ($1, $2, $3, NOW(), $4)
+       RETURNING id, clicked_at, expires_at`,
+      [postId, eventId, userId, expiresAt]
+    );
+
+    res.status(201).json({
+      success: true,
+      click: insertResult.rows[0]
+    });
+  } catch (error) {
+    if (error.message.startsWith('Invalid ')) {
+      return res.status(400).json({ message: error.message });
+    }
+    console.error('Error creating post market click:', error);
+    res.status(500).json({ message: 'Failed to register market click' });
+  }
+};
+
+exports.getPostMarkets = async (req, res) => {
+  try {
+    const postId = parseIntParam(req.params.postId, 'postId');
+
+    const result = await db.query(
+      `SELECT
+         pm.event_id,
+         e.title,
+         e.market_prob,
+         pm.match_score,
+         pm.match_method,
+         e.outcome,
+         e.closing_date
+       FROM post_market_matches pm
+       JOIN events e ON e.id = pm.event_id
+       WHERE pm.post_id = $1
+       ORDER BY pm.match_score DESC, pm.event_id ASC`,
+      [postId]
+    );
+
+    res.json({
+      post_id: postId,
+      markets: result.rows
+    });
+  } catch (error) {
+    if (error.message.startsWith('Invalid ')) {
+      return res.status(400).json({ message: error.message });
+    }
+    console.error('Error loading post markets:', error);
+    res.status(500).json({ message: 'Failed to load post markets' });
+  }
+};

--- a/backend/src/controllers/persuasiveAlphaController.js
+++ b/backend/src/controllers/persuasiveAlphaController.js
@@ -57,7 +57,7 @@ exports.createPostMarketClick = async (req, res) => {
        WHERE post_id = $1
          AND event_id = $2
          AND user_id = $3
-         AND consumed_by_market_update_id IS NULL
+         AND (consumed_by_market_update_id IS NULL OR consumed_by_market_update_id = 0)
          AND consumed_at IS NULL
          AND expires_at <= NOW()`,
       [postId, eventId, userId]

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,13 +1,32 @@
 // backend/src/db.js
 const { Pool } = require('pg');
 
-// Create a new PostgreSQL connection pool
-const pool = new Pool({
+const createPool = () => new Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
+let pool = createPool();
+
+const getActivePool = () => {
+  if (!pool || pool.ended) {
+    pool = createPool();
+  }
+  return pool;
+};
+
+const closePool = async () => {
+  if (!pool || pool.ended) {
+    pool = null;
+    return;
+  }
+
+  await pool.end();
+  pool = null;
+};
+
 // Export query method that wraps pool.query for convenience
 module.exports = {
-  query: (text, params) => pool.query(text, params),
-  getPool: () => pool,
+  query: (text, params) => getActivePool().query(text, params),
+  getPool: getActivePool,
+  closePool
 };

--- a/backend/src/services/persuasiveAlphaService.js
+++ b/backend/src/services/persuasiveAlphaService.js
@@ -1,0 +1,67 @@
+const IN_PROGRESS_MARKER = 0;
+
+const claimReferralClick = async ({ dbClient, userId, eventId }) => {
+  const result = await dbClient.query(
+    `WITH ranked_clicks AS (
+       SELECT pmc.id, pmc.post_id
+       FROM post_market_clicks pmc
+       JOIN posts p ON p.id = pmc.post_id
+       WHERE pmc.user_id = $1
+         AND pmc.event_id = $2
+         AND pmc.consumed_by_market_update_id IS NULL
+         AND pmc.expires_at > NOW()
+         AND p.user_id <> $1
+       ORDER BY pmc.clicked_at DESC
+       LIMIT 1
+       FOR UPDATE SKIP LOCKED
+     )
+     UPDATE post_market_clicks pmc
+     SET consumed_by_market_update_id = $3
+     FROM ranked_clicks rc
+     WHERE pmc.id = rc.id
+     RETURNING rc.id AS click_id, rc.post_id`,
+    [userId, eventId, IN_PROGRESS_MARKER]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return {
+    clickId: Number(result.rows[0].click_id),
+    postId: Number(result.rows[0].post_id),
+  };
+};
+
+const finalizeReferralClick = async ({ dbClient, clickId, marketUpdateId }) => {
+  const result = await dbClient.query(
+    `UPDATE post_market_clicks
+     SET consumed_by_market_update_id = $2,
+         consumed_at = NOW()
+     WHERE id = $1
+       AND consumed_by_market_update_id = 0
+     RETURNING id`,
+    [clickId, marketUpdateId]
+  );
+
+  return result.rows.length > 0;
+};
+
+const releaseReferralClick = async ({ dbClient, clickId }) => {
+  const result = await dbClient.query(
+    `UPDATE post_market_clicks
+     SET consumed_by_market_update_id = NULL
+     WHERE id = $1
+       AND consumed_by_market_update_id = 0
+     RETURNING id`,
+    [clickId]
+  );
+
+  return result.rows.length > 0;
+};
+
+module.exports = {
+  claimReferralClick,
+  finalizeReferralClick,
+  releaseReferralClick,
+};

--- a/backend/test/jest.closeDbAfterEach.js
+++ b/backend/test/jest.closeDbAfterEach.js
@@ -1,0 +1,12 @@
+const db = require('../src/db');
+
+afterAll(async () => {
+  if (process.env.NODE_ENV === 'test') {
+    try {
+      await db.closePool();
+    } catch (error) {
+      // Ensure one misbehaving test teardown does not fail the suite because of pool cleanup.
+      console.warn('[Test Teardown] Failed to close DB pool:', error?.message || error);
+    }
+  }
+});

--- a/backend/test/persuasive_alpha.test.js
+++ b/backend/test/persuasive_alpha.test.js
@@ -1,0 +1,337 @@
+const request = require('supertest');
+const { app } = require('../src/index');
+const db = require('../src/db');
+
+jest.setTimeout(30000);
+
+const ensurePersuasiveSchema = async () => {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS post_market_matches (
+      id SERIAL PRIMARY KEY,
+      post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+      event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+      match_score DECIMAL(10, 6) NOT NULL DEFAULT 0.0,
+      match_method VARCHAR(20) NOT NULL DEFAULT 'fts_v1',
+      created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+      updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+      CONSTRAINT unique_post_market_match UNIQUE (post_id, event_id)
+    )
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_post_market_matches_post
+      ON post_market_matches(post_id)
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_post_market_matches_event
+      ON post_market_matches(event_id)
+  `);
+
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS post_market_clicks (
+      id SERIAL PRIMARY KEY,
+      post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+      event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      clicked_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+      expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+      consumed_at TIMESTAMP WITH TIME ZONE,
+      consumed_by_market_update_id INTEGER,
+      CONSTRAINT post_market_clicks_post_event_user_unique_once_per_click_window
+        UNIQUE (post_id, event_id, user_id, clicked_at)
+    )
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_post_market_clicks_user_event_clicked
+      ON post_market_clicks(user_id, event_id, clicked_at DESC)
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_post_market_clicks_expires
+      ON post_market_clicks(expires_at)
+  `);
+
+  await db.query(`
+    ALTER TABLE market_updates
+      ADD COLUMN IF NOT EXISTS referral_post_id INTEGER REFERENCES posts(id) ON DELETE SET NULL
+  `);
+
+  await db.query(`
+    ALTER TABLE market_updates
+      ADD COLUMN IF NOT EXISTS referral_click_id INTEGER
+  `);
+
+  await db.query(`
+    ALTER TABLE market_updates
+      ADD COLUMN IF NOT EXISTS had_prior_position BOOLEAN NOT NULL DEFAULT FALSE
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_market_updates_referral_post
+      ON market_updates(referral_post_id, event_id)
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_market_updates_referral_click
+      ON market_updates(referral_click_id)
+  `);
+};
+
+const makeUser = async (label, verificationTier) => {
+  const unique = `${label}_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+  const email = `${unique}@example.com`;
+  const username = unique;
+  const password = 'testpass123';
+
+  await request(app)
+    .post('/api/users/register')
+    .send({ username, email, password });
+
+  const loginRes = await request(app)
+    .post('/api/login')
+    .send({ email, password });
+
+  expect(loginRes.statusCode).toBe(200);
+
+  const userResult = await db.query('SELECT id FROM users WHERE email = $1', [email]);
+  const userId = userResult.rows[0].id;
+
+  if (verificationTier !== undefined) {
+    await db.query('UPDATE users SET verification_tier = $1 WHERE id = $2', [verificationTier, userId]);
+  }
+
+  return {
+    id: userId,
+    token: loginRes.body.token
+  };
+};
+
+const createEvent = async () => {
+  const closingDate = new Date(Date.now() + (24 * 60 * 60 * 1000)).toISOString();
+  const result = await db.query(
+    `INSERT INTO events (title, details, closing_date, event_type, category)
+     VALUES ($1, $2, $3, 'binary', 'test')
+     RETURNING id, title, closing_date`,
+    [`Persuasive alpha event ${Date.now()}_${Math.floor(Math.random() * 10000)}`, 'Will this test pass?', closingDate]
+  );
+  return result.rows[0];
+};
+
+const createPost = async (user) => {
+  const res = await request(app)
+    .post('/api/posts')
+    .set('Authorization', `Bearer ${user.token}`)
+    .send({ content: `Persuasive alpha test post ${Date.now()}_${Math.floor(Math.random() * 10000)}` });
+
+  expect(res.statusCode).toBe(201);
+  expect(res.body.id).toBeDefined();
+  return res.body;
+};
+
+const createMatch = async ({ postId, eventId, matchScore = 0.9 }) => {
+  const result = await db.query(
+    'INSERT INTO post_market_matches (post_id, event_id, match_score, match_method) VALUES ($1, $2, $3, $4) RETURNING id',
+    [postId, eventId, matchScore, 'fts_v1']
+  );
+  return result.rows[0];
+};
+
+const createClick = async ({ postId, eventId, token }) => {
+  const res = await request(app)
+    .post(`/api/posts/${postId}/market-click`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({ event_id: eventId });
+
+  return res;
+};
+
+const waitForClickConsumed = async (clickId, expectedMarketUpdateId) => {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const clickRow = await db.query(
+      'SELECT consumed_by_market_update_id, consumed_at FROM post_market_clicks WHERE id = $1',
+      [clickId]
+    );
+
+    if (
+      clickRow.rows.length > 0 &&
+      clickRow.rows[0].consumed_at &&
+      Number(clickRow.rows[0].consumed_by_market_update_id) === Number(expectedMarketUpdateId)
+    ) {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  return false;
+};
+
+describe('Persuasive alpha attribution APIs', () => {
+  const cleanup = {
+    users: new Set(),
+    posts: new Set(),
+    events: new Set(),
+    matches: new Set(),
+    clicks: new Set()
+  };
+
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        new_prob: 0.55,
+        cumulative_stake: 5.0,
+        market_update_id: 1
+      })
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeAll(async () => {
+    await ensurePersuasiveSchema();
+  });
+
+  afterAll(async () => {
+    if (cleanup.clicks.size) {
+      await db.query(
+        'DELETE FROM post_market_clicks WHERE id = ANY($1::int[])',
+        [Array.from(cleanup.clicks)]
+      );
+    }
+
+    if (cleanup.matches.size) {
+      await db.query(
+        'DELETE FROM post_market_matches WHERE id = ANY($1::int[])',
+        [Array.from(cleanup.matches)]
+      );
+    }
+
+    if (cleanup.posts.size) {
+      await db.query('DELETE FROM posts WHERE id = ANY($1::int[])', [Array.from(cleanup.posts)]);
+    }
+
+    if (cleanup.events.size) {
+      await db.query('DELETE FROM events WHERE id = ANY($1::int[])', [Array.from(cleanup.events)]);
+    }
+
+    for (const userId of cleanup.users) {
+      await db.query('DELETE FROM users WHERE id = $1', [userId]);
+    }
+  });
+
+  test('POST /api/posts/:postId/market-click records a valid referral click', async () => {
+    const author = await makeUser('pa_author', 1);
+    const trader = await makeUser('pa_trader', 1);
+    cleanup.users.add(author.id);
+    cleanup.users.add(trader.id);
+
+    const event = await createEvent();
+    const post = await createPost(author);
+    cleanup.events.add(event.id);
+    cleanup.posts.add(post.id);
+
+    const match = await createMatch({ postId: post.id, eventId: event.id });
+    cleanup.matches.add(match.id);
+
+    const res = await createClick({ postId: post.id, eventId: event.id, token: trader.token });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.click).toHaveProperty('id');
+    expect(res.body.click).toHaveProperty('clicked_at');
+    expect(res.body.click).toHaveProperty('expires_at');
+
+    const clickRow = await db.query(
+      'SELECT post_id, event_id, user_id FROM post_market_clicks WHERE id = $1',
+      [res.body.click.id]
+    );
+    expect(clickRow.rows[0]).toMatchObject({
+      post_id: post.id,
+      event_id: event.id,
+      user_id: trader.id
+    });
+    cleanup.clicks.add(res.body.click.id);
+  });
+
+  test('GET /api/posts/:postId/markets returns ordered matches', async () => {
+    const author = await makeUser('pa_author2', 1);
+    cleanup.users.add(author.id);
+
+    const eventA = await createEvent();
+    const eventB = await createEvent();
+    const post = await createPost(author);
+    cleanup.events.add(eventA.id);
+    cleanup.events.add(eventB.id);
+    cleanup.posts.add(post.id);
+
+    const matchA = await createMatch({ postId: post.id, eventId: eventA.id, matchScore: 0.32 });
+    const matchB = await createMatch({ postId: post.id, eventId: eventB.id, matchScore: 0.88 });
+    cleanup.matches.add(matchA.id);
+    cleanup.matches.add(matchB.id);
+
+    const res = await request(app)
+      .get(`/api/posts/${post.id}/markets`)
+      .set('Authorization', `Bearer ${author.token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.post_id).toBe(post.id);
+    expect(Array.isArray(res.body.markets)).toBe(true);
+    expect(res.body.markets).toHaveLength(2);
+    expect(Number(res.body.markets[0].match_score)).toBeGreaterThanOrEqual(Number(res.body.markets[1].match_score));
+    expect(res.body.markets.map((market) => Number(market.event_id)).sort()).toEqual([eventA.id, eventB.id].sort());
+  });
+
+  test('Market update route links click attribution to trade payload and consumes click record', async () => {
+    const author = await makeUser('pa_author3', 1);
+    const trader = await makeUser('pa_trader3', 2);
+    cleanup.users.add(author.id);
+    cleanup.users.add(trader.id);
+
+    const event = await createEvent();
+    const post = await createPost(author);
+    cleanup.events.add(event.id);
+    cleanup.posts.add(post.id);
+
+    const match = await createMatch({ postId: post.id, eventId: event.id });
+    cleanup.matches.add(match.id);
+
+    const clickRes = await createClick({ postId: post.id, eventId: event.id, token: trader.token });
+    expect(clickRes.statusCode).toBe(201);
+    const clickId = clickRes.body.click.id;
+    cleanup.clicks.add(clickId);
+
+    const marketUpdateId = 4242;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ new_prob: 0.57, cumulative_stake: 8.0, market_update_id: marketUpdateId })
+    });
+
+    const updateRes = await request(app)
+      .post(`/api/events/${event.id}/update`)
+      .set('Authorization', `Bearer ${trader.token}`)
+      .send({ user_id: trader.id, stake: 1.5, target_prob: 0.6 });
+
+    expect(updateRes.statusCode).toBe(200);
+
+    expect(global.fetch).toHaveBeenCalled();
+    const [calledUrl, calledOptions] = global.fetch.mock.calls[0];
+    const payload = JSON.parse(calledOptions.body || '{}');
+
+    expect(calledUrl).toBe(`http://prediction-engine:3001/events/${event.id}/update`);
+    expect(payload.referral_post_id).toBe(post.id);
+    expect(payload.referral_click_id).toBe(clickId);
+    expect(payload.user_id).toBe(trader.id);
+    expect(payload.stake).toBe(1.5);
+
+    const clickConsumed = await waitForClickConsumed(clickId, marketUpdateId);
+    expect(clickConsumed).toBe(true);
+  });
+});

--- a/backend/test/persuasive_alpha.test.js
+++ b/backend/test/persuasive_alpha.test.js
@@ -372,7 +372,7 @@ describe('Persuasive alpha attribution APIs', () => {
 
   test('Market update uses the latest non-self click for referral and ignores fallback self clicks', async () => {
     const postAuthor = await makeUser('pa_post_author', 1);
-    const trader = await makeUser('pa_trader_fallback', 1);
+    const trader = await makeUser('pa_trader_fallback', 2);
     cleanup.users.add(postAuthor.id);
     cleanup.users.add(trader.id);
 
@@ -418,7 +418,7 @@ describe('Persuasive alpha attribution APIs', () => {
 
   test('Concurrent market update requests consume at most one active click', async () => {
     const author = await makeUser('pa_author_concurrency', 1);
-    const trader = await makeUser('pa_trader_concurrency', 1);
+    const trader = await makeUser('pa_trader_concurrency', 2);
     cleanup.users.add(author.id);
     cleanup.users.add(trader.id);
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,89 @@
+# Local-first compose for feature development.
+# Usage: docker compose -f docker-compose.local.yml up -d --build
+
+services:
+  db:
+    image: postgres:17-alpine
+    container_name: intellacc_db_local
+    environment:
+      POSTGRES_USER: intellacc_user
+      POSTGRES_PASSWORD: intellacc_password
+      POSTGRES_DB: intellaccdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - intellacc_db_local_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U intellacc_user -d intellaccdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - intellacc-local
+
+  backend:
+    build:
+      context: ./backend
+    container_name: intellacc_backend
+    working_dir: /usr/src/app
+    command: ["./scripts/docker-dev-entrypoint.sh"]
+    environment:
+      NODE_ENV: development
+      NODE_PORT: 3000
+      DATABASE_URL: postgres://intellacc_user:intellacc_password@db:5432/intellaccdb
+      JWT_SECRET: local-dev-jwt-secret
+      FRONTEND_URL: http://localhost:5173
+      PREDICTION_ENGINE_AUTH_TOKEN: local-dev-prediction-engine-token
+    volumes:
+      - ./backend/src:/usr/src/app/src
+      - ./backend/test:/usr/src/app/test
+      - ./backend/migrations:/usr/src/app/migrations
+      - ./backend/uploads:/usr/src/app/uploads
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - intellacc-local
+
+  prediction-engine:
+    build:
+      context: ./prediction-engine
+    container_name: intellacc_prediction_engine
+    environment:
+      DATABASE_URL: postgres://intellacc_user:intellacc_password@db:5432/intellaccdb
+      RUST_LOG: info
+      PREDICTION_ENGINE_AUTH_TOKEN: local-dev-prediction-engine-token
+    ports:
+      - "3001:3001"
+    depends_on:
+      db:
+        condition: service_healthy
+      backend:
+        condition: service_started
+    networks:
+      - intellacc-local
+
+  frontend:
+    build:
+      context: ./frontend
+    container_name: intellacc_frontend
+    command: sh -lc "npm install && npm install @rollup/rollup-linux-x64-musl --save-optional && npm run dev -- --host 0.0.0.0"
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    depends_on:
+      - backend
+    networks:
+      - intellacc-local
+
+volumes:
+  intellacc_db_local_data:
+  frontend_node_modules:
+
+networks:
+  intellacc-local:
+    driver: bridge

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -25,6 +25,7 @@ services:
     build:
       context: ./backend
     container_name: intellacc_backend_dev
+    hostname: intellacc_backend_dev
     working_dir: /usr/src/app
     command: ["./scripts/docker-dev-entrypoint.sh"]
     environment:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,16 +1,16 @@
-# Local-first compose for feature development.
+# Local-only compose for feature development.
 # Usage: docker compose -f docker-compose.local.yml up -d --build
 
 services:
   db:
     image: postgres:17-alpine
-    container_name: intellacc_db_local
+    container_name: intellacc_db_dev
     environment:
       POSTGRES_USER: intellacc_user
       POSTGRES_PASSWORD: intellacc_password
       POSTGRES_DB: intellaccdb
     ports:
-      - "5432:5432"
+      - "15432:5432"
     volumes:
       - intellacc_db_local_data:/var/lib/postgresql/data
     healthcheck:
@@ -19,12 +19,12 @@ services:
       timeout: 5s
       retries: 10
     networks:
-      - intellacc-local
+      - intellacc-local-dev
 
   backend:
     build:
       context: ./backend
-    container_name: intellacc_backend
+    container_name: intellacc_backend_dev
     working_dir: /usr/src/app
     command: ["./scripts/docker-dev-entrypoint.sh"]
     environment:
@@ -32,7 +32,7 @@ services:
       NODE_PORT: 3000
       DATABASE_URL: postgres://intellacc_user:intellacc_password@db:5432/intellaccdb
       JWT_SECRET: local-dev-jwt-secret
-      FRONTEND_URL: http://localhost:5173
+      FRONTEND_URL: http://localhost:5175
       PREDICTION_ENGINE_AUTH_TOKEN: local-dev-prediction-engine-token
     volumes:
       - ./backend/src:/usr/src/app/src
@@ -40,50 +40,50 @@ services:
       - ./backend/migrations:/usr/src/app/migrations
       - ./backend/uploads:/usr/src/app/uploads
     ports:
-      - "3000:3000"
+      - "3005:3000"
     depends_on:
       db:
         condition: service_healthy
     networks:
-      - intellacc-local
+      - intellacc-local-dev
 
   prediction-engine:
     build:
       context: ./prediction-engine
-    container_name: intellacc_prediction_engine
+    container_name: intellacc_prediction_engine_dev
     environment:
       DATABASE_URL: postgres://intellacc_user:intellacc_password@db:5432/intellaccdb
       RUST_LOG: info
       PREDICTION_ENGINE_AUTH_TOKEN: local-dev-prediction-engine-token
     ports:
-      - "3001:3001"
+      - "3006:3001"
     depends_on:
       db:
         condition: service_healthy
       backend:
         condition: service_started
     networks:
-      - intellacc-local
+      - intellacc-local-dev
 
   frontend:
     build:
       context: ./frontend
-    container_name: intellacc_frontend
+    container_name: intellacc_frontend_dev
     command: sh -lc "npm install && npm install @rollup/rollup-linux-x64-musl --save-optional && npm run dev -- --host 0.0.0.0"
     ports:
-      - "5173:5173"
+      - "5175:5173"
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
     depends_on:
       - backend
     networks:
-      - intellacc-local
+      - intellacc-local-dev
 
 volumes:
   intellacc_db_local_data:
   frontend_node_modules:
 
 networks:
-  intellacc-local:
+  intellacc-local-dev:
     driver: bridge

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -28,6 +28,7 @@ services:
     working_dir: /usr/src/app
     command: ["./scripts/docker-dev-entrypoint.sh"]
     environment:
+      INTELLACC_STACK: development
       NODE_ENV: development
       NODE_PORT: 3000
       DATABASE_URL: postgres://intellacc_user:intellacc_password@db:5432/intellaccdb

--- a/docs/WEEKLY_ASSIGNMENT_CRON.md
+++ b/docs/WEEKLY_ASSIGNMENT_CRON.md
@@ -128,7 +128,7 @@ Users receive +50 RP bonus if they:
 
 1. **"Backend container not running"**
    ```bash
-   docker compose -f docker-compose-dev.yml up -d
+   ./scripts/dev-stack.sh up
    ```
 
 2. **"No suitable events available"**

--- a/docs/persuasive-alpha-v1-implementation-plan.md
+++ b/docs/persuasive-alpha-v1-implementation-plan.md
@@ -1,0 +1,320 @@
+# Persuasive Alpha v1: Truth-Weighted Marginal Information Scoring for Posts
+
+## Summary
+Implement a production-safe, attribution-backed reward system for high-signal posts using the agreed model:
+
+- Scope: all posts with auto market matching
+- Signal metric: marginal information value from attributed trade episodes
+- Horizon mix: 24h / 7d / final = 0.2 / 0.3 / 0.5
+- Wrong-direction handling: zero floor (no negative score in v1)
+- Payout model: per-score minting (with hard caps)
+- Settlement: nightly batch + final on event resolution
+- Reliability: uniform initial user weights in v1 (`r_u = 1.0`)
+
+This plan is tailored to current code reality:
+- No existing post->trade attribution chain exists yet.
+- `market_updates` currently records buy/update trades; sell-side rows are not recorded.
+- Existing reward runner pattern exists (`market-questions/rewards/run`) and should be reused.
+
+## 1. Product and Behavior Spec
+
+### 1.1 Attribution chain (required for any reward)
+Instrument this canonical chain:
+
+`post viewed/clicked market chip -> attribution click record -> trade update -> attributed episode`
+
+Rules:
+- Attribution is set server-side only (never trust client-provided `referral_post_id`).
+- Self-attribution excluded (`post_author_id == trader_user_id` => drop attribution).
+- One-click can only attribute trades for same `event_id`.
+- Click validity window: default 30 minutes (configurable).
+- Attribution consumed per dedupe episode (see below), not per raw click.
+
+### 1.2 Episode definition (anti-splitting)
+Convert raw attributed market updates into episodes.
+
+Episode key:
+- `(trader_user_id, post_id, event_id, side, window_bucket)`
+
+Window bucket:
+- 15-minute buckets (configurable).
+
+Meaningful update thresholds:
+- `abs(new_prob - prev_prob) >= 0.01` OR `stake_amount_ledger >= 1_000_000` (1 RP)
+- If below both thresholds => ignore for scoring.
+
+Episode type classification:
+- If user had prior position in event before update (see schema below) => `belief_update`
+- Else => `attention_update`
+- Both can score in v1; `belief_update` gets multiplier > `attention_update`.
+
+Default multipliers:
+- `belief_update = 1.0`
+- `attention_update = 0.35`
+
+### 1.3 Score computation per episode
+For each episode, compute:
+
+- `p_before = market prob before update`
+- `p_after = market prob after update`
+- `target_24h = market consensus at t + 24h`
+- `target_7d = market consensus at t + 7d`
+- `target_final = resolved outcome prob (1 or 0) when resolved`
+
+Proper-score delta:
+- `Delta_h = LogLoss(target_h, p_before) - LogLoss(target_h, p_after)`
+
+Horizon score with zero floor:
+- `S_h = max(0, Delta_h)`
+
+Combined episode score:
+- `S_episode = r_u * m_episode * (0.2*S_24h + 0.3*S_7d + 0.5*S_final)`
+
+Where:
+- `r_u = 1.0` in v1 (uniform reliability)
+- `m_episode` is type multiplier (`belief` vs `attention`)
+
+### 1.4 Post score and payout
+Post score:
+- Sum all finalized episode scores attributed to `post_id`.
+
+Payout (per-score minting):
+- `reward_ledger = floor(score * mint_rate_ledger_per_point)`
+
+Safety caps:
+- Max reward per post per event per day.
+- Max reward per author per day.
+- Max system mint per day (global circuit breaker).
+
+Finalization:
+- 24h/7d components awarded when horizon matures.
+- Final component awarded only after event resolves.
+
+## 2. Data Model and Schema Changes
+
+### 2.1 New tables
+1. `post_market_matches`
+- `id`
+- `post_id` FK posts
+- `event_id` FK events
+- `match_score` numeric
+- `match_method` (`fts_v1`, future `hybrid_v2`)
+- `created_at`
+- unique `(post_id, event_id)`
+
+2. `post_market_clicks`
+- `id`
+- `post_id`
+- `event_id`
+- `user_id`
+- `clicked_at`
+- `expires_at`
+- `consumed_at` nullable
+- `consumed_by_market_update_id` nullable FK market_updates
+- index `(user_id, event_id, clicked_at desc)`
+
+3. `post_signal_episodes`
+- `id`
+- `market_update_id` unique FK market_updates
+- `post_id`, `event_id`, `trader_user_id`
+- `episode_bucket_start`
+- `episode_type` (`attention`, `belief`)
+- `is_meaningful` bool
+- `p_before`, `p_after`
+- `s_24h`, `s_7d`, `s_final` nullable
+- `finalized_24h_at`, `finalized_7d_at`, `finalized_final_at` nullable
+- `combined_score`
+- `created_at`, `updated_at`
+- indexes on `(post_id)`, `(event_id)`, `(trader_user_id)`, `(episode_bucket_start)`
+
+4. `post_signal_reward_payouts` (audit/idempotency)
+- `id`
+- `episode_id` FK post_signal_episodes
+- `post_id`, `author_user_id`, `event_id`
+- `component` (`24h`, `7d`, `final`)
+- `score_component`
+- `mint_rate_snapshot`
+- `reward_ledger`
+- `payout_status`
+- `created_at`
+- unique `(episode_id, component)` for idempotency
+
+### 2.2 Alter existing `market_updates`
+Add nullable fields:
+- `referral_post_id` FK posts
+- `referral_click_id` FK post_market_clicks
+- `had_prior_position` boolean default false
+
+Rationale:
+- keeps attribution tied to immutable trade records and simplifies scoring.
+
+## 3. API and Interface Changes
+
+### 3.1 Backend API (new)
+1. `POST /api/posts/:postId/market-click`
+- Body: `{ event_id }`
+- Auth required.
+- Validates `(post,event)` match exists.
+- Writes `post_market_clicks` row.
+- Returns `{ success: true }`.
+
+2. `GET /api/posts/:postId/markets`
+- Returns matched markets for rendering under post.
+
+### 3.2 Backend API (existing route behavior change)
+`POST /api/events/:eventId/update`
+- Before proxying to prediction-engine:
+  - lookup latest unexpired `post_market_clicks` for `(user,event)`
+  - validate self-referral exclusion
+  - pass server-validated referral context downstream
+- No client-supplied referral accepted.
+
+### 3.3 Prediction-engine contract change
+`MarketUpdate` payload adds optional:
+- `referral_post_id?: i32`
+- `referral_click_id?: i32`
+
+`UpdateResult` adds:
+- `market_update_id: i32` (RETURNING id from insert)
+
+Needed so backend can mark click consumed and build deterministic episode links.
+
+## 4. Matching and Feed Integration
+
+### 4.1 Matching engine v1
+- Use PostgreSQL full-text match against event title/details.
+- Trigger matching:
+  - on post create/update
+  - on event create/update (backfill recent posts)
+- Keep top `N=3` matches above threshold.
+
+### 4.2 UI updates
+- Under each post, render matched markets chip list.
+- Click behavior:
+  - call `POST /posts/:postId/market-click`
+  - navigate user to market view.
+- No reward-specific UI needed in first release beyond author-side "signal stats" page.
+
+## 5. Scoring Jobs and Runtime
+
+### 5.1 Nightly scorer job (new)
+Batch job performs:
+1. Build/refresh episodes from newly attributed `market_updates`.
+2. Finalize 24h and 7d components for mature episodes.
+3. Write payouts idempotently (`post_signal_reward_payouts`) and credit author `rp_balance_ledger`.
+
+### 5.2 Finalization on resolution
+When event resolves:
+- finalize `s_final` for unresolved final components.
+- mint final payouts idempotently.
+
+Implementation path:
+- Add service module `postSignalScoringService`.
+- Add admin route:
+  - `POST /api/posts/signal/rewards/run` (mirrors market-question runner pattern).
+- Add to existing weekly/manual cron docs and optional nightly cron service.
+
+## 6. Abuse and Safety Controls (v1 hard requirements)
+
+- Self-referral exclusion.
+- Meaningful update threshold.
+- Episode dedupe window.
+- Per-post daily cap.
+- Per-author daily cap.
+- Global daily mint cap (hard stop).
+- Minimum account requirements for rewarded authors:
+  - account age >= X days (configurable)
+  - email verified minimum (reuse verification tier).
+
+Moderation integration:
+- If post removed/flagged for manipulation, future payouts blocked.
+- Optional clawback deferred to v1.1 (log but do not auto-debit in v1).
+
+## 7. Testing and Acceptance Criteria
+
+### 7.1 Unit tests
+1. Attribution validation:
+- accepts only unexpired click with same `(user,event)`.
+- rejects self-referral.
+- rejects mismatched event click.
+2. Episode builder:
+- dedupe by 15-min bucket.
+- threshold filters dust.
+- attention vs belief classification by prior position.
+3. Score math:
+- logloss delta correctness.
+- zero-floor enforcement.
+- horizon weighting.
+4. Payout caps:
+- per-post, per-author, global cap behavior.
+5. Idempotency:
+- rerunning jobs does not duplicate payouts.
+
+### 7.2 Integration tests
+1. End-to-end attributed reward:
+- create post -> match event -> click -> trade -> nightly run -> payout row + author RP increment.
+2. Unattributed trade:
+- trade without click yields no episode.
+3. Self-referral:
+- author clicks own post and trades => no attribution.
+4. Superseded information:
+- positive 24h/7d but zero final still yields partial per design.
+5. Resolution finalization:
+- unresolved episodes gain final component only after event outcome set.
+6. Conflict/retry safety:
+- concurrent batch runs still produce single payout rows.
+
+### 7.3 Performance tests
+- nightly job runtime across realistic `market_updates` volume.
+- indexes verified with explain plans for attribution lookup and episode scans.
+
+## 8. Rollout Plan
+
+1. **Phase A (shadow mode, no minting)**
+- full attribution + episode + score computation
+- store scores, no payouts
+- monitor gaming patterns and score distribution for 2 weeks.
+
+2. **Phase B (capped minting on)**
+- enable payout with conservative mint rate and strict caps
+- keep admin kill switch.
+
+3. **Phase C (tuning)**
+- tune thresholds, episode window, multipliers, mint rate.
+- optionally introduce non-uniform `r_u` in v1.1.
+
+Observability:
+- metrics: attributed trade rate, episode counts, score distribution, payout totals, cap-hit frequency, flagged abuse counts.
+
+## 9. Explicit Interfaces / Type Additions
+
+### Backend DTOs
+- `PostMarketClickRequest { event_id: number }`
+- `PostMarketMatch { event_id, title, market_prob, match_score }`
+- `SignalRewardRunResult { processed_updates, episodes_created, payouts_count, minted_ledger_total, capped_count }`
+
+### Prediction-engine DTO updates
+- `MarketUpdate` add optional `referral_post_id`, `referral_click_id`
+- `UpdateResult` add `market_update_id`
+
+### Config additions
+- `POST_SIGNAL_CLICK_TTL_MIN=30`
+- `POST_SIGNAL_EPISODE_WINDOW_MIN=15`
+- `POST_SIGNAL_MIN_PROB_DELTA=0.01`
+- `POST_SIGNAL_MIN_STAKE_LEDGER=1000000`
+- `POST_SIGNAL_MINT_RATE_LEDGER_PER_POINT`
+- `POST_SIGNAL_CAP_PER_POST_PER_DAY_LEDGER`
+- `POST_SIGNAL_CAP_PER_AUTHOR_PER_DAY_LEDGER`
+- `POST_SIGNAL_CAP_GLOBAL_PER_DAY_LEDGER`
+- `POST_SIGNAL_BELIEF_MULTIPLIER=1.0`
+- `POST_SIGNAL_ATTENTION_MULTIPLIER=0.35`
+
+## 10. Assumptions and Defaults Chosen
+
+- Eligible scope: all posts with auto-match.
+- Wrong-direction scoring: zero floor.
+- Horizon weights: 0.2 / 0.3 / 0.5 (24h/7d/final).
+- Reliability weighting: uniform in v1 (`r_u=1.0`).
+- Funding: per-score minting with strict caps.
+- Settlement cadence: nightly + final on resolution.
+- v1 uses buy/update-side `market_updates` as attribution source; sell-side attribution deferred unless sell logging is added.

--- a/prediction-engine/src/main.rs
+++ b/prediction-engine/src/main.rs
@@ -912,6 +912,16 @@ async fn update_market_endpoint(
         event_id,
         target_prob,
         stake,
+        referral_post_id: payload
+            .get("referral_post_id")
+            .and_then(|value| value.as_i64())
+            .filter(|value| *value > 0)
+            .map(|value| value as i32),
+        referral_click_id: payload
+            .get("referral_click_id")
+            .and_then(|value| value.as_i64())
+            .filter(|value| *value > 0)
+            .map(|value| value as i32),
     };
 
     match lmsr_api::update_market(&app_state.db, &app_state.config, user_id, update).await {

--- a/prediction-engine/src/stress.rs
+++ b/prediction-engine/src/stress.rs
@@ -198,6 +198,9 @@ pub async fn setup_test_database(pool: &PgPool) -> Result<()> {
             stake_amount_ledger BIGINT NOT NULL,
             shares_acquired DOUBLE PRECISION NOT NULL CHECK (shares_acquired > 0),
             share_type VARCHAR(10) NOT NULL CHECK (share_type IN ('yes', 'no')),
+            referral_post_id INTEGER,
+            referral_click_id INTEGER,
+            had_prior_position BOOLEAN NOT NULL DEFAULT FALSE,
             hold_until TIMESTAMP WITH TIME ZONE NOT NULL,
             created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
         )
@@ -413,6 +416,8 @@ async fn try_execute_trade(
         event_id,
         target_prob: belief,
         stake,
+        referral_post_id: None,
+        referral_click_id: None,
     };
 
     // Execute the trade

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.local.yml"
+ALLOW_PRODUCTION="${INTELLACC_ALLOW_PROD_STACK_OVERLAP:-0}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/dev-stack.sh up [extra docker compose args]
+  ./scripts/dev-stack.sh down [extra docker compose args]
+  ./scripts/dev-stack.sh logs [extra docker compose args]
+  ./scripts/dev-stack.sh status
+
+Set INTELLACC_ALLOW_PRODUCTION=1 to run this command while production containers are running.
+EOF
+}
+
+has_running_container() {
+  local name="$1"
+  docker ps --filter "name=^/${name}$" --format '{{.Names}}' | grep -Fxq "$name"
+}
+
+ensure_not_running_on_production() {
+  local collision=0
+
+  if has_running_container intellacc_backend || \
+     has_running_container intellacc_frontend || \
+     has_running_container intellacc_db || \
+     has_running_container intellacc_prediction_engine; then
+    collision=1
+  fi
+
+  if [ "$collision" -eq 1 ] && [ "$ALLOW_PRODUCTION" != "1" ]; then
+    echo "Refusing to start local stack because production containers are running:"
+    docker ps --filter "name=^/(intellacc_backend|intellacc_frontend|intellacc_db|intellacc_prediction_engine)$" \
+      --format '  {{.Names}} ({{.Status}})'
+    echo
+    echo "If you know this is expected, run with INTELLACC_ALLOW_PRODUCTION=1."
+    exit 1
+  fi
+}
+
+main() {
+  local cmd="${1:-up}"
+  shift || true
+
+  case "$cmd" in
+    up|start)
+      ensure_not_running_on_production
+      docker compose -f "$COMPOSE_FILE" up -d --build "$@"
+      ;;
+    down)
+      docker compose -f "$COMPOSE_FILE" down "$@"
+      ;;
+    logs)
+      docker compose -f "$COMPOSE_FILE" logs "$@"
+      ;;
+    status)
+      docker compose -f "$COMPOSE_FILE" ps "$@"
+      ;;
+    -h|--help|help|"")
+      usage
+      ;;
+    *)
+      echo "Unknown command: $cmd"
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -12,7 +12,7 @@ Usage:
   ./scripts/dev-stack.sh logs [extra docker compose args]
   ./scripts/dev-stack.sh status
 
-Set INTELLACC_ALLOW_PRODUCTION=1 to run this command while production containers are running.
+Set INTELLACC_ALLOW_PROD_STACK_OVERLAP=1 to run this command while production containers are running.
 EOF
 }
 
@@ -36,7 +36,7 @@ ensure_not_running_on_production() {
     docker ps --filter "name=^/(intellacc_backend|intellacc_frontend|intellacc_db|intellacc_prediction_engine)$" \
       --format '  {{.Names}} ({{.Status}})'
     echo
-    echo "If you know this is expected, run with INTELLACC_ALLOW_PRODUCTION=1."
+    echo "If you know this is expected, run with INTELLACC_ALLOW_PROD_STACK_OVERLAP=1."
     exit 1
   fi
 }

--- a/scripts/run_populate.sh
+++ b/scripts/run_populate.sh
@@ -23,7 +23,7 @@ fi
 if ! docker ps | grep -q intellacc_db; then
     echo "❌ Database container is not running!"
     echo "Please start the database first with:"
-    echo "   docker compose -f docker-compose-dev.yml up -d"
+    echo "   ./scripts/dev-stack.sh up"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Hardened transaction lifecycle and cleanup in `POST /api/events/:eventId/update` handler.
- Updated persuasive-alpha test fixtures for required verification tiers used by protected routes.
- Added local compose hostname alignment (`intellacc_backend_dev`) to keep `docker-compose.local.yml` compatible with the dev entrypoint guard.
- Relaxed production startup hostname enforcement so `backend/scripts/docker-dev-entrypoint.sh` only validates hostname when `INTELLACC_BACKEND_HOSTNAME` is explicitly configured.
- Corrected `scripts/dev-stack.sh` usage/help text to use `INTELLACC_ALLOW_PROD_STACK_OVERLAP` (actual environment variable).

## Testing
- `bash -n backend/scripts/docker-dev-entrypoint.sh scripts/dev-stack.sh`
- `npx jest test/persuasive_alpha.test.js --runInBand`
- `npx jest --runInBand`

## Notes
- Latest change is `6899fd8` (PR head now includes `8be5d60`, `6899fd8`).
- No production services/containers were modified by this patch path; this branch is still intended for local/dev-stack validation and test execution via source-mounted compose.
- No code-path behavior changes were made beyond production startup guard hardening and documentation alignment for dev-stack overlap flag.