### PR TITLE
Add market lifecycle rejection coverage

### DIFF
--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -387,6 +387,29 @@ router.post("/events/:eventId/update", authenticateJWT, requirePhoneVerified, as
     }
 
     try {
+      const eventResult = await db.query(
+        'SELECT outcome, closing_date FROM events WHERE id = $1',
+        [eventIdNumber]
+      );
+
+      if (eventResult.rows.length === 0) {
+        return res.status(404).json({ message: 'Event not found' });
+      }
+
+      const { outcome, closing_date } = eventResult.rows[0];
+      if (outcome) {
+        return res.status(400).json({ error: 'Market resolved', event_id: eventIdNumber });
+      }
+
+      if (closing_date && new Date(closing_date).getTime() <= Date.now()) {
+        return res.status(400).json({ error: 'Market closed', event_id: eventIdNumber });
+      }
+    } catch (error) {
+      console.error('Error loading event lifecycle state:', error);
+      return res.status(500).json({ error: 'Failed to validate event state' });
+    }
+
+    try {
         client = await db.getPool().connect();
         await client.query('BEGIN');
         inTransaction = true;

--- a/backend/test/market_lifecycle.test.js
+++ b/backend/test/market_lifecycle.test.js
@@ -1,0 +1,132 @@
+const request = require('supertest');
+const { app } = require('../src/index');
+const db = require('../src/db');
+
+jest.setTimeout(30000);
+
+const makeUser = async (label, verificationTier = 2) => {
+  const unique = `${label}_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+  const email = `${unique}@example.com`;
+  const username = unique;
+  const password = 'testpass123';
+
+  await request(app)
+    .post('/api/users/register')
+    .send({ username, email, password });
+
+  const loginRes = await request(app)
+    .post('/api/login')
+    .send({ email, password });
+  expect(loginRes.statusCode).toBe(200);
+
+  const userResult = await db.query('SELECT id FROM users WHERE email = $1', [email]);
+  const userId = userResult.rows[0].id;
+
+  await db.query('UPDATE users SET verification_tier = $1 WHERE id = $2', [verificationTier, userId]);
+
+  return { id: userId, token: loginRes.body.token };
+};
+
+const createEvent = async ({
+  outcome = null,
+  closingDate = new Date(Date.now() + (24 * 60 * 60 * 1000))
+}) => {
+  const result = await db.query(
+    `INSERT INTO events (title, details, closing_date, outcome)
+     VALUES ($1, $2, $3, $4) RETURNING id`,
+    [`Lifecycle market ${Date.now()}_${Math.floor(Math.random() * 10000)}`, 'Lifecycle coverage test', closingDate, outcome]
+  );
+
+  return result.rows[0];
+};
+
+describe('Market lifecycle rejection coverage', () => {
+  const cleanup = {
+    users: new Set(),
+    events: new Set()
+  };
+
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        new_prob: 0.55,
+        cumulative_stake: 4.0,
+        market_update_id: 99
+      })
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  afterAll(async () => {
+    for (const eventId of cleanup.events) {
+      await db.query('DELETE FROM events WHERE id = $1', [eventId]);
+    }
+    for (const userId of cleanup.users) {
+      await db.query('DELETE FROM users WHERE id = $1', [userId]);
+    }
+  });
+
+  test('rejects closed market updates before calling prediction engine', async () => {
+    const user = await makeUser('closed_market_user');
+    const closedEvent = await createEvent({
+      closingDate: new Date(Date.now() - 5 * 60 * 1000)
+    });
+
+    cleanup.users.add(user.id);
+    cleanup.events.add(closedEvent.id);
+
+    const res = await request(app)
+      .post(`/api/events/${closedEvent.id}/update`)
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ user_id: user.id, stake: 1.0, target_prob: 0.6 });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Market closed');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('rejects resolved market updates before calling prediction engine', async () => {
+    const user = await makeUser('resolved_market_user');
+    const resolvedEvent = await createEvent({
+      outcome: 'resolved'
+    });
+
+    cleanup.users.add(user.id);
+    cleanup.events.add(resolvedEvent.id);
+
+    const res = await request(app)
+      .post(`/api/events/${resolvedEvent.id}/update`)
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ user_id: user.id, stake: 1.0, target_prob: 0.6 });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Market resolved');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('does not block open-market updates when event is still active', async () => {
+    const user = await makeUser('open_market_user');
+    const activeEvent = await createEvent({
+      closingDate: new Date(Date.now() + 5 * 60 * 1000)
+    });
+
+    cleanup.users.add(user.id);
+    cleanup.events.add(activeEvent.id);
+
+    const res = await request(app)
+      .post(`/api/events/${activeEvent.id}/update`)
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ user_id: user.id, stake: 1.0, target_prob: 0.6 });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('market_update_id', 99);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/unified-backlog.md
+++ b/docs/unified-backlog.md
@@ -46,8 +46,8 @@ This backlog was re-audited item-by-item against the repository (frontend, backe
   low-level `selfUpdate()` exists, but no periodic scheduler and no manual "Refresh Keys" settings UI found.
 - `Partial` MLS staged-welcome inspection UI:
   pending invite accept/reject exists, but member fingerprint inspection before acceptance is still missing.
-- `Partial` Market lifecycle tests:
-  resolved-market rejection is covered in prediction-engine integration tests, but explicit closed-market rejection integration coverage is still missing.
+- `Done` Market lifecycle tests:
+  backend coverage now verifies closed-market and resolved-market trade rejection in `/api/events/:eventId/update` plus open-market pass-through behavior.
 
 ## Priority 2 - Medium
 - `Partial` Profile editing:


### PR DESCRIPTION
## Summary\n- Add closed/resolved market guards in /api/events/:eventId/update before LMSR call.\n- Add integration coverage for closed-market, resolved-market, and open-market pass-through behavior.\n- Update prediction-engine header test to use a real event fixture so it still hits validation path.\n- Mark item 49 as done in docs/unified-backlog.md.\n\n## Testing\n- docker exec intellacc_backend_dev npm test\n- Result: PASS (16/16 suites, 67/67 tests)